### PR TITLE
[RT#107039] fixed obsolete entry format

### DIFF
--- a/lib/Locale/PO.pm
+++ b/lib/Locale/PO.pm
@@ -278,16 +278,16 @@ sub dump {
         . $self->_fuzzy_normalize_str($self->fuzzy_msgid_plural, $fuzzy_prefix)
         if $self->fuzzy_msgid_plural;
 
-    $dump .= "${obsolete}msgctxt " . $self->_normalize_str($self->msgctxt)
+    $dump .= "${obsolete}msgctxt " . $self->_fuzzy_normalize_str($self->msgctxt, $obsolete)
         if $self->msgctxt;
-    $dump .= "${obsolete}msgid " . $self->_normalize_str($self->msgid);
-    $dump .= "${obsolete}msgid_plural " . $self->_normalize_str($self->msgid_plural)
+    $dump .= "${obsolete}msgid " . $self->_fuzzy_normalize_str($self->msgid, $obsolete);
+    $dump .= "${obsolete}msgid_plural " . $self->_fuzzy_normalize_str($self->msgid_plural, $obsolete)
         if $self->msgid_plural;
 
-    $dump .= "${obsolete}msgstr " . $self->_normalize_str($self->msgstr) if $self->msgstr;
+    $dump .= "${obsolete}msgstr " . $self->_fuzzy_normalize_str($self->msgstr, $obsolete) if $self->msgstr;
 
     if (my $msgstr_n = $self->msgstr_n) {
-        $dump .= "${obsolete}msgstr[$_] " . $self->_normalize_str($$msgstr_n{$_})
+        $dump .= "${obsolete}msgstr[$_] " . $self->_fuzzy_normalize_str($$msgstr_n{$_}, $obsolete)
             for sort { $a <=> $b } keys %$msgstr_n;
     }
 

--- a/t/RT107039.po
+++ b/t/RT107039.po
@@ -1,0 +1,50 @@
+# Japanese translations for test package
+# test パッケージに対する英訳.
+# Copyright (C) 2015 THE test'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the test package.
+# Automatically generated, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: test version\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-09-11 09:00+0900\n"
+"PO-Revision-Date: 2015-09-11 09:00+0900\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: test.c:13
+#, c-format
+#~ msgid "TEST: msgid singleline"
+#~ msgstr "TEST: msgstr singleline"
+
+#: test.c:14
+#, c-format
+#~ msgid "TEST: msgid multi\n"
+#~ "line"
+#~ msgstr "TEST: msgstr multi\n"
+#~ "line"
+
+#: test.c:17
+#, c-format
+#~ msgctxt "TEST: mgsctxt singleline"
+#~ msgid "TEST: msgid singleline"
+#~ msgid_plural "TEST: msgid_plural singleline"
+#~ msgstr[0] "TEST: msgstr[0] singleline"
+
+#: test.c:20
+#, c-format
+#~ msgctxt "TEST: mgsctxt multi\n"
+#~ "line"
+#~ msgid "TEST: msgid multi\n"
+#~ "line"
+#~ msgid_plural "TEST: msgid_plural multi\n"
+#~ "line"
+#~ msgstr[0] "TEST: msgstr[0] multi\n"
+#~ "line"
+

--- a/t/RT107039.t
+++ b/t/RT107039.t
@@ -1,0 +1,97 @@
+
+=head1 NAME
+
+t/RT107039.t
+
+=head1 DESCRIPTION
+
+Tests formatting of obsolete entries.
+
+	Invalid formatting of obsolete entries
+	
+	When one entry is obsoleted and have multiple lines
+	of msgctxt/msgid/msgid_plural/msgstr/msgstr[*],
+	save_file_fromarray and save_file_fromhash will generate
+	invalid file: GNU gettext tools like megcat and msgattrib
+	will abnormally be terminated with "fatal errors" and
+	"inconsistent use of #~" messages.
+	
+	[1] https://rt.cpan.org/Ticket/Display.html?id=107039
+
+=head1 EXAMPLE
+
+	# Japanese translations for test package
+	# test パッケージに対する英訳.
+	# Copyright (C) 2015 THE test'S COPYRIGHT HOLDER
+	# This file is distributed under the same license as the test package.
+	# Automatically generated, 2015.
+	#
+	msgid ""
+	msgstr ""
+	"Project-Id-Version: test version\n"
+	"Report-Msgid-Bugs-To: \n"
+	"POT-Creation-Date: 2015-09-11 09:00+0900\n"
+	"PO-Revision-Date: 2015-09-11 09:00+0900\n"
+	"Last-Translator: Automatically generated\n"
+	"Language-Team: none\n"
+	"Language: ja\n"
+	"MIME-Version: 1.0\n"
+	"Content-Type: text/plain; charset=UTF-8\n"
+	"Content-Transfer-Encoding: 8bit\n"
+	"Plural-Forms: nplurals=1; plural=0;\n"
+
+	#: test.c:13
+	#, c-format
+	#~ msgid "TEST: msgid singleline"
+	#~ msgstr "TEST: msgstr singleline"
+
+	#: test.c:14
+	#, c-format
+	#~ msgid "TEST: msgid multi\n"
+	#~ "line"
+	#~ msgstr "TEST: msgstr multi\n"
+	#~ "line"
+
+	#: test.c:17
+	#, c-format
+	#~ msgctxt "TEST: mgsctxt singleline"
+	#~ msgid "TEST: msgid singleline"
+	#~ msgid_plural "TEST: msgid_plural singleline"
+	#~ msgstr[0] "TEST: msgstr[0] singleline"
+
+	#: test.c:20
+	#, c-format
+	#~ msgctxt "TEST: mgsctxt multi\n"
+	#~ "line"
+	#~ msgid "TEST: msgid multi\n"
+	#~ "line"
+	#~ msgid_plural "TEST: msgid_plural multi\n"
+	#~ "line"
+	#~ msgstr[0] "TEST: msgstr[0] multi\n"
+	#~ "line"
+
+=cut
+
+use strict;
+use warnings;
+
+use Test::More;
+use Locale::PO;
+use File::Temp qw/tempfile tempdir/;
+use File::Compare;
+
+my $no_tests = 2;
+
+plan tests => $no_tests;
+
+my $file = "t/RT107039.po";
+my $aref = Locale::PO->load_file_asarray($file);
+ok( $aref, "loaded ${file} file" );
+
+my ( $tempfh, $tempfile ) = tempfile;
+Locale::PO->save_file_fromarray( $tempfile, $aref );
+close $tempfh;
+
+ok( compare( $file, $tempfile ) == 0, "compare test" );
+
+1;


### PR DESCRIPTION
Dear authors,

When one entry is obsoleted and have multiple lines of msgctxt/msgid/msgid_plural/msgstr/msgstr[*], save_file_fromarray and save_file_fromhash will generate invalid file: GNU gettext tools like megcat and msgattrib will abnormally be terminated with "fatal errors" and "inconsistent use of #~" messages.

I just reported this bug on cpan [1]. I would like to merge my work on your master branch.

[1] https://rt.cpan.org/Ticket/Display.html?id=107039

Sincerely yours,
Ryuunosuke Ayanokouzi
